### PR TITLE
add mc-appimage-builder: build AppImage package for Linux

### DIFF
--- a/mc-appimage-builder/Dockerfile
+++ b/mc-appimage-builder/Dockerfile
@@ -34,6 +34,8 @@ RUN apt update && apt full-upgrade -y && apt install -y --no-install-recommends 
     build-essential \
     pkg-config \
     libcairo2 \
+    libegl1-mesa \
+    libfuse2 \
     libgl1-mesa-dev \
     libsm6 \
     libice6 \
@@ -41,7 +43,9 @@ RUN apt update && apt full-upgrade -y && apt install -y --no-install-recommends 
     libxrender1 \
     libfontconfig1 \
     libdbus-1-3 \
-    libusb-1.0-0-dev
+    libusb-1.0-0-dev \
+    libxi6
+
 
 COPY extract-qt-installer.sh /tmp/qt/
 
@@ -58,24 +62,29 @@ RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
 # Add group & user + sudo
 RUN groupadd -r ubuntu && useradd --create-home --gid ubuntu ubuntu && echo 'ubuntu ALL=NOPASSWD: ALL' > /etc/sudoers.d/ubuntu
 
+# dirty hack. Probably it's better try to switch on rhel7 template which is officially supported by Qt 5.9.6:
+# https://wiki.qt.io/Qt_5.9_Tools_and_Versions
+# For QtDBus.so libdbus 1.3 is needed.
+RUN echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" > /etc/apt/sources.list.d/xenial.list && \
+    apt-get update && \
+    apt-get install -y libdbus-1-3
 
-# FIXME: put it in a list afterwards: (do not change the order now to leverage 'docker build' cache)
-RUN apt-get install -y libfuse2
 
-# get linuxdeploy's AppImage
+# Inside Docker fuse mount will not work, so extract AppImages:
+# https://github.com/AppImage/AppImageKit/issues/405
+
+# get linuxdeploy
 RUN curl -4 -LO "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" && \
     chmod +x linuxdeploy-x86_64.AppImage && \
     ./linuxdeploy-x86_64.AppImage --appimage-extract && \
     rm -f linuxdeploy-x86_64.AppImage && \
-    mv squashfs-root linuxdeploy-x86_64.AppDir && \
-    chown -R ubuntu:ubuntu linuxdeploy-x86_64.AppDir
+    mv squashfs-root linuxdeploy-x86_64.AppDir
 
-
-# dirty hack. Probably it's better try to switch on rhel7 template which is officially supported by Qt 5.9.6:
-# https://wiki.qt.io/Qt_5.9_Tools_and_Versions
-# Also git tag --points-at=HEAD --sort version:refname         doesn't work with git from Ubuntu 14.04 (unknown option --sort)
-RUN echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" > /etc/apt/sources.list.d/xenial.list && \
-    apt-get update && \
-    apt-get install -y libdbus-1-3 git
+# get linuxdeploy Qt plugin:
+RUN curl -4 -LO "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage" && \
+    chmod +x linuxdeploy-plugin-qt-x86_64.AppImage && \
+    ./linuxdeploy-plugin-qt-x86_64.AppImage --appimage-extract && \
+    rm -f linuxdeploy-plugin-qt-x86_64.AppImage && \
+    mv squashfs-root linuxdeploy-plugin-qt-x86_64.AppDir
 
 COPY scripts /scripts

--- a/mc-appimage-builder/Dockerfile
+++ b/mc-appimage-builder/Dockerfile
@@ -1,0 +1,81 @@
+# Official Qt installer is based on https://github.com/rabits/dockerfiles
+
+FROM ubuntu:14.04
+
+MAINTAINER Alexander Sashnov "sashnov@ngs.ru"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ENV QT_VERSION  5.9.6
+ENV QT_PATH /opt/Qt
+ENV QT_DESKTOP $QT_PATH/${QT_VERSION}/gcc_64
+
+ENV PATH    $QT_DESKTOP/bin:$PATH
+ENV HOME    /home/ubuntu
+
+# WORKDIR directive will create the directory automatically
+WORKDIR     /home/ubuntu
+
+# Install updates & requirements:
+#  * git, openssh-client, ca-certificates - clone & build
+#  * locales, sudo - useful to set utf-8 locale & sudo usage
+#  * curl - to download Qt bundle
+#  * build-essential, pkg-config, libgl1-mesa-dev - basic Qt build requirements
+#  * libsm6, libice6, libxext6, libxrender1, libfontconfig1, libdbus-1-3 - dependencies of the Qt bundle run-file
+#  * libcairo2 needed for running appimagetool
+#  * libusb-1.0-0-dev needed by Moolticute daemon
+RUN apt update && apt full-upgrade -y && apt install -y --no-install-recommends \
+    git \
+    openssh-client \
+    ca-certificates \
+    locales \
+    sudo \
+    curl \
+    build-essential \
+    pkg-config \
+    libcairo2 \
+    libgl1-mesa-dev \
+    libsm6 \
+    libice6 \
+    libxext6 \
+    libxrender1 \
+    libfontconfig1 \
+    libdbus-1-3 \
+    libusb-1.0-0-dev
+
+COPY extract-qt-installer.sh /tmp/qt/
+
+# Download & unpack Qt toolchains & clean
+# Note curl -4 option: this is workaround for 'unable to resolve host' in ubuntu:14.04 container
+RUN curl -4 -Lo /tmp/qt/installer.run "https://download.qt.io/official_releases/online_installers/qt-unified-linux-x64-online.run" \
+    && QT_CI_PACKAGES=qt.$(echo "${QT_VERSION}" | tr -d .).gcc_64 /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
+    && find "$QT_PATH" -mindepth 1 -maxdepth 1 ! -name "${QT_VERSION}" -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
+    && rm -rf /tmp/qt
+
+# Reconfigure locale
+RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
+
+# Add group & user + sudo
+RUN groupadd -r ubuntu && useradd --create-home --gid ubuntu ubuntu && echo 'ubuntu ALL=NOPASSWD: ALL' > /etc/sudoers.d/ubuntu
+
+
+# FIXME: put it in a list afterwards: (do not change the order now to leverage 'docker build' cache)
+RUN apt-get install -y libfuse2
+
+# get linuxdeploy's AppImage
+RUN curl -4 -LO "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage" && \
+    chmod +x linuxdeploy-x86_64.AppImage && \
+    ./linuxdeploy-x86_64.AppImage --appimage-extract && \
+    rm -f linuxdeploy-x86_64.AppImage && \
+    mv squashfs-root linuxdeploy-x86_64.AppDir && \
+    chown -R ubuntu:ubuntu linuxdeploy-x86_64.AppDir
+
+
+# dirty hack. Probably it's better try to switch on rhel7 template which is officially supported by Qt 5.9.6:
+# https://wiki.qt.io/Qt_5.9_Tools_and_Versions
+# Also git tag --points-at=HEAD --sort version:refname         doesn't work with git from Ubuntu 14.04 (unknown option --sort)
+RUN echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" > /etc/apt/sources.list.d/xenial.list && \
+    apt-get update && \
+    apt-get install -y libdbus-1-3 git
+
+COPY scripts /scripts

--- a/mc-appimage-builder/README.md
+++ b/mc-appimage-builder/README.md
@@ -1,0 +1,49 @@
+# Moolticute docker for building AppImage
+
+This docker is used by to build/package moolticute for AppImage (Linux)
+
+# Usage
+
+Download the latest image from docker hub
+```bash
+➜ docker pull mooltipass/mc-appimage-builder
+Using default tag: latest
+latest: Pulling from mooltipass/mc-appimage-builder
+Digest: sha256:5c7be97f9d27853455d96d05cedcacbe89b276706e21cdc9a9ed67047e598ff3
+Status: Image is up to date for mooltipass/mc-appimage-builder:latest
+```
+
+Clone the moolticute source repository somewhere on you hdd.
+```bash
+➜ git clone https://github.com/mooltipass/moolticute
+[...]
+```
+
+Then you need to tell docker where to map the source code of moolticute.
+
+Start the docker
+```bash
+➜ docker run -t --name appimage-builder -d -v ABSOLUTE_PATH_TO_YOUR_SRC/moolticute:/moolticute mooltipass/mc-appimage-builder
+8aa6768f752515f8f9a7a3c82213813225aea7ef950799e065e7426b296d6902
+```
+
+The docker is running, you can check with:
+```bash
+➜ docker ps
+CONTAINER ID IMAGE        COMMAND     CREATED        STATUS  PORTS   NAMES
+8aa6768f7525 a1c24aecf093 "/bin/bash" 36 seconds ago Up 33 seconds   appimage-builder
+```
+
+Now it's time to start the build:
+```bash
+➜ docker exec appimage-builder /bin/bash /scripts/build.sh
+[...]
+```
+
+And finally to create the packages:
+```bash
+➜ docker exec appimage-builder /bin/bash /scripts/package.sh
+[...]
+```
+
+AppImage file is now available in your moolticute source dir (in the build-appimage folder)

--- a/mc-appimage-builder/extract-qt-installer.sh
+++ b/mc-appimage-builder/extract-qt-installer.sh
@@ -1,0 +1,109 @@
+#!/bin/sh -e
+# QT-CI Project
+# License: Apache-2.0
+# https://github.com/benlau/qtci
+
+if [ $# -lt 2 ];
+then
+    echo extract-qt-installer qt-installer output_path
+    exit -1
+fi
+
+INSTALLER=$1
+OUTPUT=$2
+SCRIPT="$(mktemp /tmp/tmp.XXXXXXXXX)"
+PACKAGES=$QT_CI_PACKAGES
+
+cat <<EOF > $SCRIPT
+function Controller() {
+    installer.installationFinished.connect(function() {
+        gui.clickButton(buttons.NextButton);
+    });
+
+    installer.setMessageBoxAutomaticAnswer("OverwriteTargetDirectory", QMessageBox.Yes);
+    installer.setMessageBoxAutomaticAnswer("installationErrorWithRetry", QMessageBox.Ignore);
+
+}
+
+Controller.prototype.WelcomePageCallback = function() {
+    console.log("Welcome Page");
+    gui.clickButton(buttons.NextButton, 10000);
+}
+
+Controller.prototype.CredentialsPageCallback = function() {
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.ComponentSelectionPageCallback = function() {
+    console.log("Select components");
+
+    function trim(str) {
+        return str.replace(/^ +/,"").replace(/ *$/,"");
+    }
+
+    var widget = gui.currentPageWidget();
+
+    var packages = trim("$PACKAGES").split(",");
+    if (packages.length > 0 && packages[0] !== "") {
+        widget.deselectAll();
+        for (var i in packages) {
+            var pkg = trim(packages[i]);
+            console.log("Select " + pkg);
+            widget.selectComponent(pkg);
+        }
+    } else {
+       console.log("Use default component list");
+    }
+
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.IntroductionPageCallback = function() {
+    console.log("Introduction Page");
+    console.log("Retrieving meta information from remote repository");
+    gui.clickButton(buttons.NextButton);
+}
+
+
+Controller.prototype.TargetDirectoryPageCallback = function() {
+    console.log("Set target installation page: $OUTPUT");
+    var widget = gui.currentPageWidget();
+
+    if (widget != null) {
+        widget.TargetDirectoryLineEdit.setText("$OUTPUT");
+    }
+
+    gui.clickButton(buttons.NextButton);
+
+}
+
+Controller.prototype.LicenseAgreementPageCallback = function() {
+    console.log("Accept license agreement");
+    var widget = gui.currentPageWidget();
+
+    if (widget != null) {
+        widget.AcceptLicenseRadioButton.setChecked(true);
+    }
+
+    gui.clickButton(buttons.NextButton);
+
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function() {
+    console.log("Ready to install");
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.FinishedPageCallback = function() {
+    var widget = gui.currentPageWidget();
+
+    if (widget.LaunchQtCreatorCheckBoxForm) {
+        // No this form for minimal platform
+        widget.LaunchQtCreatorCheckBoxForm.launchQtCreatorCheckBox.setChecked(false);
+    }
+    gui.clickButton(buttons.FinishButton);
+}
+EOF
+
+chmod u+x $INSTALLER
+QT_QPA_PLATFORM=minimal $INSTALLER -v --script $SCRIPT

--- a/mc-appimage-builder/scripts/build.sh
+++ b/mc-appimage-builder/scripts/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+set -x
+set -u
+
+cd /moolticute
+
+export ARCH=$(arch)
+
+APP=moolticute
+LOWERAPP=${APP,,}
+
+
+BASE_PATH="$PWD/build-appimage"
+
+BUILD_DIR="$BASE_PATH/build-qmake-release"
+
+
+# https://docs.appimage.org/packaging-guide/from-source/native-binaries.html#qmake
+mkdir -p $BUILD_DIR
+cd $BUILD_DIR
+
+qmake CONFIG+=release PREFIX=/usr ../../Moolticute.pro
+make

--- a/mc-appimage-builder/scripts/package.sh
+++ b/mc-appimage-builder/scripts/package.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# https://github.com/linuxdeploy/linuxdeploy-plugin-qt-examples/blob/master/build_appimages.sh
 set -e
 set -x
 set -u
@@ -14,7 +14,7 @@ LOWERAPP=${APP,,}
 BASE_PATH="$PWD/build-appimage"
 
 BUILD_DIR="$BASE_PATH/build-qmake-release"
-APPDIR="$BASE_PATH/$APP.AppDir/"
+APPDIR="$BASE_PATH/$APP.AppDir"
 
 # it's just 7 sec to re-create, and linuxdeploy fails if it's not clean
 rm -rf "$APPDIR"
@@ -37,12 +37,16 @@ cd $BASE_PATH
 export LD_LIBRARY_PATH="/opt/Qt/5.9.6/gcc_64/lib/:${LD_LIBRARY_PATH:-}"
 
 # Use appimage plugin to create .AppImage also: https://github.com/linuxdeploy/linuxdeploy-plugin-appimage
-~/linuxdeploy-x86_64.AppDir/AppRun --appdir "$APPDIR" --output appimage
+~/linuxdeploy-x86_64.AppDir/AppRun --app-name ${APP} --verbosity=0 --appdir "$APPDIR"
+~/linuxdeploy-plugin-qt-x86_64.AppDir/AppRun --appdir "$APPDIR"
 
 
-# FIXME: Qt plugins are not packed into
-# and PATH, LD_LIBRARY_PATH, QTDIR seems also to be not set.
-# TODO: read packing manual, see examples of Qt apps package
-# (when it's packed from .deb package in AppImage/AppImages .deb doesn't include Qt plugins, right?
-# TODO: read through https://github.com/AppImage/AppImageSpec/blob/master/draft.md
-# TODO: look through AppRun sources- does it setup this variables?
+# workaround: for some strange reasons moolticute.desktop and moolticute.svg are
+# turned into a self-symlink
+rm "$APPDIR/moolticute.desktop"
+cp "$APPDIR/usr/share/applications/moolticute.desktop" "$APPDIR/"
+
+rm "$APPDIR/moolticute.svg"
+cp "$APPDIR//usr/share/icons/hicolor/scalable/apps/moolticute.svg" "$APPDIR/"
+
+~/linuxdeploy-x86_64.AppDir/AppRun --app-name ${APP} --verbosity=0 --appdir "$APPDIR" --output appimage

--- a/mc-appimage-builder/scripts/package.sh
+++ b/mc-appimage-builder/scripts/package.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+set -x
+set -u
+
+cd /moolticute
+
+export ARCH=$(arch)
+
+APP=moolticute
+LOWERAPP=${APP,,}
+
+BASE_PATH="$PWD/build-appimage"
+
+BUILD_DIR="$BASE_PATH/build-qmake-release"
+APPDIR="$BASE_PATH/$APP.AppDir/"
+
+# it's just 7 sec to re-create, and linuxdeploy fails if it's not clean
+rm -rf "$APPDIR"
+rm -f  "$BASE_PATH/Moolticute-x86_64.AppImage"
+
+( cd $BUILD_DIR ; make install INSTALL_ROOT=$APPDIR )
+
+cp data/moolticute.sh "$APPDIR/usr/bin/"
+sed -i 's#Exec=/usr/bin/moolticute#Exec=moolticute.sh#g' "$APPDIR/usr/share/applications/moolticute.desktop"
+
+cd $BASE_PATH
+
+# Example on how to use linuxdeploy Qt plugin properly:
+# https://github.com/linuxdeploy/linuxdeploy-plugin-qt-examples/blob/master/build_appimages.sh
+
+# https://docs.appimage.org/packaging-guide/from-source/native-binaries.html#qmake
+
+
+# Fix for "ERROR: Could not find dependency: libicuuc.so.56"
+export LD_LIBRARY_PATH="/opt/Qt/5.9.6/gcc_64/lib/:${LD_LIBRARY_PATH:-}"
+
+# Use appimage plugin to create .AppImage also: https://github.com/linuxdeploy/linuxdeploy-plugin-appimage
+~/linuxdeploy-x86_64.AppDir/AppRun --appdir "$APPDIR" --output appimage
+
+
+# FIXME: Qt plugins are not packed into
+# and PATH, LD_LIBRARY_PATH, QTDIR seems also to be not set.
+# TODO: read packing manual, see examples of Qt apps package
+# (when it's packed from .deb package in AppImage/AppImages .deb doesn't include Qt plugins, right?
+# TODO: read through https://github.com/AppImage/AppImageSpec/blob/master/draft.md
+# TODO: look through AppRun sources- does it setup this variables?


### PR DESCRIPTION
This Docker image is based on Ubuntu 14.04 and
official Qt 5.9.6 build.

AppImage build procedure uses linuxdeploy with qt and appimage plugins.