### PR TITLE
Fix building error after --app-name was removed from LinuxDeploy

### DIFF
--- a/mc-appimage-builder/scripts/package.sh
+++ b/mc-appimage-builder/scripts/package.sh
@@ -37,7 +37,7 @@ cd $BASE_PATH
 export LD_LIBRARY_PATH="/opt/Qt/5.9.6/gcc_64/lib/:${LD_LIBRARY_PATH:-}"
 
 # Use appimage plugin to create .AppImage also: https://github.com/linuxdeploy/linuxdeploy-plugin-appimage
-~/linuxdeploy-x86_64.AppDir/AppRun --app-name ${APP} --verbosity=0 --appdir "$APPDIR"
+~/linuxdeploy-x86_64.AppDir/AppRun --verbosity=0 --appdir "$APPDIR"
 ~/linuxdeploy-plugin-qt-x86_64.AppDir/AppRun --appdir "$APPDIR"
 
 
@@ -49,4 +49,4 @@ cp "$APPDIR/usr/share/applications/moolticute.desktop" "$APPDIR/"
 rm "$APPDIR/moolticute.svg"
 cp "$APPDIR//usr/share/icons/hicolor/scalable/apps/moolticute.svg" "$APPDIR/"
 
-~/linuxdeploy-x86_64.AppDir/AppRun --app-name ${APP} --verbosity=0 --appdir "$APPDIR" --output appimage
+~/linuxdeploy-x86_64.AppDir/AppRun --verbosity=0 --appdir "$APPDIR" --output appimage


### PR DESCRIPTION
Fix building error after --app-name was removed from LinuxDeploy
by upstream commit https://github.com/linuxdeploy/linuxdeploy/commit/c8d78eb6026e50ec1361d87cc3107c775c190c69

The error was:
```
$ docker exec mc-appimage-builder /bin/bash /scripts/package.sh
....
+ /home/ubuntu/linuxdeploy-x86_64.AppDir/AppRun --app-name moolticute --verbosity=0 --appdir /moolticute/build-appimage/moolticute.AppDir
Flag could not be matched: app-name
```