### PR TITLE
AppImage builder: get OpenSSL 1.0.2g from Ubuntu 16.04

### DIFF
--- a/mc-appimage-builder/Dockerfile
+++ b/mc-appimage-builder/Dockerfile
@@ -65,9 +65,24 @@ RUN groupadd -r ubuntu && useradd --create-home --gid ubuntu ubuntu && echo 'ubu
 # dirty hack. Probably it's better try to switch on rhel7 template which is officially supported by Qt 5.9.6:
 # https://wiki.qt.io/Qt_5.9_Tools_and_Versions
 # For QtDBus.so libdbus 1.3 is needed.
+#
+# Also, upgrade OpenSSL from 1.0.1f (ubuntu 14.04)   to  1.0.2g (ubuntu 16.04)
+# With version from Ubuntu 14.04 QSslSocket prints:
+#
+# WARNING: :0 - QSslSocket: cannot resolve SSL_set_alpn_protos
+# WARNING: :0 - QSslSocket: cannot resolve SSL_CTX_set_alpn_select_cb
+# WARNING: :0 - QSslSocket: cannot resolve SSL_get0_alpn_selected
+# - stil not prints it's not compatible, so seems OK, but:
+#
+# Updates checking in Moolticute doesn't work:
+#
+# INFO: :0 - Checking software updates from  "https://api.github.com/repos/mooltipass/moolticute/releases"
+# (then no output)
+#
+# TO CHECK: Maybe this is because the lack of "engines/" directory for libcrypto.
 RUN echo "deb http://archive.ubuntu.com/ubuntu/ xenial main" > /etc/apt/sources.list.d/xenial.list && \
     apt-get update && \
-    apt-get install -y libdbus-1-3
+    apt-get install -y libdbus-1-3 libssl1.0.0
 
 
 # Inside Docker fuse mount will not work, so extract AppImages:

--- a/mc-appimage-builder/scripts/package.sh
+++ b/mc-appimage-builder/scripts/package.sh
@@ -36,6 +36,47 @@ cd $BASE_PATH
 # Fix for "ERROR: Could not find dependency: libicuuc.so.56"
 export LD_LIBRARY_PATH="/opt/Qt/5.9.6/gcc_64/lib/:${LD_LIBRARY_PATH:-}"
 
+
+
+
+# Copy OpenSSL 1.0 manually because QSslSocket loads it dynamically in runtime.
+# QSslSocket class uses some hieristic to choose 'best' OpenSSL.
+# So we have to create different symlinks to trick it
+# and pick ours library from this AppImage bundle
+mkdir -p "$APPDIR/usr/lib"
+SSLLIBNAME="libssl.so.1.0.0"
+cp "/lib/x86_64-linux-gnu/$SSLLIBNAME" "$APPDIR/usr/lib/"
+
+# http://code.qt.io/cgit/qt/qtbase.git/tree/src/network/ssl/qsslsocket_openssl_symbols.cpp?h=5.9.6#n662
+#    // The right thing to do is to load the library at the major version we know how
+#    // to work with: the SHLIB_VERSION_NUMBER version (macro defined in opensslv.h)
+#
+# But there is no way to get this value from Qt5Network other than:
+#   $ strings ~/moolticute/build-appimage/moolticute.AppDir/usr/lib/libQt5Network.so.5 | grep '^1\.0'
+#   1.0.2k
+SHLIB_VERSION_NUMBER=`strings "${QT_PATH}/${QT_VERSION}/gcc_64/lib/libQt5Network.so" | grep '^1\.0' | head -n 1`
+
+if [ -n "$SHLIB_VERSION_NUMBER" ] ; then
+    echo "This QSslSocket was compiled agains $SHLIB_VERSION_NUMBER"
+
+    # Creating links to libssl.so.<SHLIB_VERSION_NUMBER> and libcrypto.so.<SHLIB_VERSION_NUMBER>
+    # to trigger first attempt case so no other libraries will be checked:
+    #
+    # http://code.qt.io/cgit/qt/qtbase.git/tree/src/network/ssl/qsslsocket_openssl_symbols.cpp?h=5.9.6#n682
+    #    // first attempt: the canonical name is libssl.so.<SHLIB_VERSION_NUMBER>
+    #    libssl->setFileNameAndVersion(QLatin1String("ssl"), QLatin1String(SHLIB_VERSION_NUMBER));
+    #    libcrypto->setFileNameAndVersion(QLatin1String("crypto"), QLatin1String(SHLIB_VERSION_NUMBER));
+    #    if (libcrypto->load() && libssl->load()) {
+    #        // libssl.so.<SHLIB_VERSION_NUMBER> and libcrypto.so.<SHLIB_VERSION_NUMBER> found
+    #        return pair;
+
+    ln -s "$SSLLIBNAME" "$APPDIR/usr/lib/libssl.so.${SHLIB_VERSION_NUMBER}"
+    ln -s "libcrypto.so.1.0.0" "$APPDIR/usr/lib/libcrypto.so.${SHLIB_VERSION_NUMBER}"
+fi
+
+
+
+
 # Use appimage plugin to create .AppImage also: https://github.com/linuxdeploy/linuxdeploy-plugin-appimage
 ~/linuxdeploy-x86_64.AppDir/AppRun --verbosity=0 --appdir "$APPDIR"
 ~/linuxdeploy-plugin-qt-x86_64.AppDir/AppRun --appdir "$APPDIR"

--- a/mc-appimage-builder/scripts/package.sh
+++ b/mc-appimage-builder/scripts/package.sh
@@ -74,7 +74,9 @@ if [ -n "$SHLIB_VERSION_NUMBER" ] ; then
     ln -s "libcrypto.so.1.0.0" "$APPDIR/usr/lib/libcrypto.so.${SHLIB_VERSION_NUMBER}"
 fi
 
-
+# Also get OpenSSL config:
+mkdir -p "$APPDIR/usr/lib/ssl/"
+cp "/usr/lib/ssl/openssl.cnf" "$APPDIR/usr/lib/ssl"
 
 
 # Use appimage plugin to create .AppImage also: https://github.com/linuxdeploy/linuxdeploy-plugin-appimage


### PR DESCRIPTION
Get OpenSSL 1.0.2g from Ubuntu 16.04
Create symlinks with a version official Qt was build against (1.0.2k)

Now it seems that ours libssl and libcrypto is used, but when I click 'Check For Updates' it just prints one line "Checking software updates from ..." and nothing else:

[console_output_and_diagnostic_of_used_version_libssl.txt](https://github.com/mooltipass/mc-dockers/files/2498348/console_output_and_diagnostic_of_used_version_libssl.txt)

I thought it maybe because libcrypto searches plugins (engines) in:
```
root@2bb45fc9ff0a:~# strings /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 | grep engines
ENGINE_load_builtin_engines
engines section error
/usr/lib/x86_64-linux-gnu/openssl-1.0.0/engines
engines
```
But in strace log I see no attempt to use them:
```
ubuntu@ubuntu:~/Downloads$ grep engines moolticute.strace.log 
6638  stat("/tmp/.mount_MooltiG86vFx/usr/plugins/iconengines/.",  <unfinished ...>
6638  stat("/tmp/.mount_MooltiG86vFx/usr/bin/iconengines/.", 0x7ffc35efe060) = -1 ENOENT (No such file or directory)

```
So need to investigate it on the Moolticute side. Maybe it doesn't like version 11.11 made up by me (it is not listed in the fetched releases file)